### PR TITLE
firebase/php-jwt version conflict resolved

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=7.0",
-    "firebase/php-jwt": "^5.2",
+    "firebase/php-jwt": "^5.0",
     "ext-json": "*",
     "ext-curl": "*",
     "ext-openssl": "*"


### PR DESCRIPTION
Hi,

When trying to install your SDK through composer i've found versions conflict of the package `firebase/php-jwt`. For e.g. with the package https://packagist.org/packages/google/auth which also is using `firebase/php-jwt`.

Composer throws error as below:
```
Problem 1
    - Can only install one of: firebase/php-jwt[v5.2.0, v5.0.0].
```