### PR TITLE
Removed utf8 encode deprecated in PHP 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The PHP SDK, provides a PHP interface for the Gigya API.
 The library makes it simple to integrate Gigya services in your PHP application.
 
 ## Requirements
-[PHP 7.x.](https://www.php.net/downloads) , [PHP 8.1](https://www.php.net/downloads)
+[PHP 8.0.x, PHP 8.1.x, PHP 8.2.x](https://www.php.net/downloads)
 
 ## Download and Installation
 ### Standalone

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,12 @@
   "version": "3.0.3",
   "license": "Apache-2.0",
   "require": {
-    "php": ">=8.0 <8.2",
+    "php": ">=8.0",
     "firebase/php-jwt": "^6.0",
     "ext-json": "*",
     "ext-curl": "*",
-    "ext-openssl": "*"
+    "ext-openssl": "*",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5"

--- a/src/SigUtils.php
+++ b/src/SigUtils.php
@@ -58,7 +58,7 @@ class SigUtils
 
     static function calcSignature($baseString, $key)
     {
-        $baseString = mb_convert_encoding($baseString, 'uTF-8', mb_list_encodings());
+        $baseString = mb_convert_encoding($baseString, 'UTF-8', mb_list_encodings());
         $rawHmac = hash_hmac("sha1", $baseString, base64_decode($key), true);
 
         return base64_encode($rawHmac);

--- a/src/SigUtils.php
+++ b/src/SigUtils.php
@@ -58,8 +58,8 @@ class SigUtils
 
     static function calcSignature($baseString, $key)
     {
-        $baseString = utf8_encode($baseString);
-        $rawHmac = hash_hmac("sha1", utf8_encode($baseString), base64_decode($key), true);
+		$baseString = mb_convert_encoding($baseString, 'uTF-8', mb_list_encodings());
+        $rawHmac = hash_hmac("sha1", $baseString, base64_decode($key), true);
 
         return base64_encode($rawHmac);
     }

--- a/src/SigUtils.php
+++ b/src/SigUtils.php
@@ -58,7 +58,7 @@ class SigUtils
 
     static function calcSignature($baseString, $key)
     {
-		$baseString = mb_convert_encoding($baseString, 'uTF-8', mb_list_encodings());
+        $baseString = mb_convert_encoding($baseString, 'uTF-8', mb_list_encodings());
         $rawHmac = hash_hmac("sha1", $baseString, base64_decode($key), true);
 
         return base64_encode($rawHmac);


### PR DESCRIPTION
Removed utf8 encode deprecated in PHP 8.2