### PR TITLE
us/CXCDC-35465 | implement dynamic mTLS domain resolution

### DIFF
--- a/src/GSRequest.php
+++ b/src/GSRequest.php
@@ -112,6 +112,22 @@ class GSRequest
     }
     
     /**
+     * Resolves the mTLS domain based on the configured API domain.
+     *
+     * Extracts the datacenter from the API domain (the first segment before the first dot)
+     * and returns mtls.{datacenter}.gigya.com.
+     *
+     * @return string The mTLS domain (e.g. mtls.eu1.gigya.com)
+     */
+    public function getMtlsDomain()
+    {
+        $parts = explode('.', $this->apiDomain);
+        $datacenter = $parts[0] ?: 'us1';
+
+        return 'mtls.' . $datacenter . '.gigya.com';
+    }
+
+    /**
      * Sets the client certificate for mTLS authentication
      * 
      * Supports both file paths and PEM content strings:
@@ -175,9 +191,9 @@ class GSRequest
             $this->path = "/" . $this->method;
         }
         
-        // When using mTLS, always use accounts.gigya.com as the host
+        // When using mTLS, override the host with the mTLS domain
         if ($this->clientCertPath && $this->clientKeyPath) {
-            $this->host = "accounts.gigya.com";
+            $this->host = $this->getMtlsDomain();
         }
         
         //set json as default format.

--- a/tests/GSRequestMtlsDomainTest.php
+++ b/tests/GSRequestMtlsDomainTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Gigya\PHP\Test;
+
+use Gigya\PHP\GSRequest;
+use PHPUnit\Framework\TestCase;
+
+class GSRequestMtlsDomainTest extends TestCase
+{
+    /**
+     * @dataProvider mtlsDomainProvider
+     */
+    public function testGetMtlsDomain(string $apiDomain, string $expectedMtlsDomain)
+    {
+        $request = new GSRequest('testApiKey', null, 'accounts.getAccountInfo', null, true, 'testUserKey', 'testPrivateKey');
+        $request->setAPIDomain($apiDomain);
+
+        $this->assertEquals($expectedMtlsDomain, $request->getMtlsDomain());
+    }
+
+    public function mtlsDomainProvider(): array
+    {
+        return [
+            'US1 datacenter'     => ['us1.gigya.com', 'mtls.us1.gigya.com'],
+            'EU1 datacenter'     => ['eu1.gigya.com', 'mtls.eu1.gigya.com'],
+            'EU2 datacenter'     => ['eu2.gigya.com', 'mtls.eu2.gigya.com'],
+            'AU1 datacenter'     => ['au1.gigya.com', 'mtls.au1.gigya.com'],
+            'Global datacenter'  => ['global.gigya.com', 'mtls.global.gigya.com'],
+            'Staging datacenter' => ['us1-st1.gigya.com', 'mtls.us1-st1.gigya.com'],
+        ];
+    }
+
+    public function testGetMtlsDomainDefaultsToUs1()
+    {
+        $request = new GSRequest('testApiKey', null, 'accounts.getAccountInfo', null, true, 'testUserKey', 'testPrivateKey');
+
+        $this->assertEquals('mtls.us1.gigya.com', $request->getMtlsDomain());
+    }
+
+    /**
+     * @dataProvider missingDcProvider
+     */
+    public function testGetMtlsDomainWhenDcDoesNotExist(string $apiDomain, string $expectedMtlsDomain)
+    {
+        $request = new GSRequest('testApiKey', null, 'accounts.getAccountInfo', null, true, 'testUserKey', 'testPrivateKey');
+        $request->setAPIDomain($apiDomain);
+
+        $this->assertEquals($expectedMtlsDomain, $request->getMtlsDomain());
+    }
+
+    public function missingDcProvider(): array
+    {
+        return [
+            'empty string falls back to default'  => ['', 'mtls.us1.gigya.com'],
+            'bare domain without dc prefix'        => ['gigya.com', 'mtls.gigya.gigya.com'],
+            'leading dot (empty dc segment)'       => ['.gigya.com', 'mtls.us1.gigya.com'],
+        ];
+    }
+}


### PR DESCRIPTION
Replace hardcoded accounts.gigya.com with dynamic mtls.{datacenter}.gigya.com based on the configured API domain.